### PR TITLE
Update webpack in peerDependencies to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   },
   "peerDependencies": {
     "primus": "^7.2.2",
-    "webpack": "^3.0.0"
+    "webpack": "^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {},
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/newyork-anthonyng/primus-webpack-plugin.git"
+    "url": "git+ssh://git@github.com/DomHoney/primus-webpack-plugin.git"
   },
   "keywords": [
     "webpack-plugin",
@@ -14,12 +14,12 @@
     "primus",
     "sockets"
   ],
-  "author": "newyork.anthonyng@gmail.com",
+  "author": "DomHoney",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/newyork-anthonyng/primus-webpack-plugin/issues"
+    "url": "https://github.com/DomHoney/primus-webpack-plugin/issues"
   },
-  "homepage": "https://github.com/newyork-anthonyng/primus-webpack-plugin#readme",
+  "homepage": "https://github.com/DomHoney/primus-webpack-plugin#readme",
   "dependencies": {
     "uglify-js": "^2.8.7"
   },


### PR DESCRIPTION
Stops npm from complaining about unmet webpack@3 peer dependency after `npm install` when using webpack@4